### PR TITLE
32 bytes version of the depacker.

### DIFF
--- a/zdepack.s
+++ b/zdepack.s
@@ -1,6 +1,7 @@
 ;---------------------------------------------------------------------
 ;	zdepack
 ;	by zerkman / Sector One
+;	size optimisation by Ben / OVR
 ;---------------------------------------------------------------------
 
 ; Copyright (c) 2020-2023 Francois Galea <fgalea at free.fr>
@@ -12,7 +13,7 @@
 
 ; unpack data chunk
 ; parameters:
-; a0: beginning of packed data
+; a0: beginning of packed data
 ; a1: unpack buffer
 ; a2: end of packed data
 ; returned value:
@@ -36,7 +37,6 @@ rawlp:	move.b	(a0)+,(a1)+
 offset:
 	move.b	(a0)+,d1
 	addq.b	#3,d0
-	
 
 offlp:	move.b	(a1,d1.w),(a1)+
 	subq.b	#1,d0

--- a/zdepack.s
+++ b/zdepack.s
@@ -17,21 +17,26 @@
 ; a2: end of packed data
 ; returned value:
 ; a1: end of unpacked data
-zdepack:
-next:
-	move.b	(a0)+,d0
-	moveq	#$ffffffc0,d1
-	cmp.b	d1,d0
-	bcs.s	offset
 
-raw:	sub.b	d1,d0
+zdepack:
+	moveq	#-1,d1
+next:
+	moveq.l	#191,d0
+	sub.b	(a0)+,d0
+	bcc.s	offset
+
+	;; d0 => -1 .. -64
+raw:
 rawlp:	move.b	(a0)+,(a1)+
-	subq.b	#1,d0
-	bcc.s	rawlp
+	addq.b	#1,d0
+	bne.s	rawlp
 	bra.s	test
 
-offset:	move.b	(a0)+,d1	; offset
-	addq.b	#3,d0		; size
+	;; d0 => 0..191
+offset:
+	move.b	(a0)+,d1
+	addq.b	#3,d0
+	
 
 offlp:	move.b	(a1,d1.w),(a1)+
 	subq.b	#1,d0

--- a/zpack.c
+++ b/zpack.c
@@ -47,7 +47,7 @@ static uint8_t * encode_back(uint8_t * out, int offset, int n)
   assert( offset >= -256 );
   assert( n >= 4 );
   assert( n <= 195 );
-  *out++ = n - 4;
+  *out++ = 195 - n;
   *out++ = offset;
   return out;
 }
@@ -116,7 +116,7 @@ long unpack(uint8_t *out, const uint8_t *in, long size) {
       int offset;
       offset = -256 | (signed char)(*r++);
       /* printf("size=%d offset=%d\n", size, offset); */
-      size += 4;
+      size = 195 - size;
       assert( size >= 4 );
       assert( size <= 195 );
       do {


### PR DESCRIPTION
a slight modification in the encoding format was neccessary to decrease down to 32 bytes the depacker routine.